### PR TITLE
Enable Anthropic's server-side web search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ logs/
 *.dylib
 bin/
 dist/
+claudine
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -106,6 +106,50 @@ curl http://localhost:4000/v1/chat/completions \
 - Set `api_key` to any value (proxy handles auth)
 - See [OpenAI Python SDK](https://github.com/openai/openai-python) or [Node.js SDK](https://github.com/openai/openai-node)
 
+### Web Search
+
+Claude can search the web to answer questions requiring current information. Enable web search by setting an environment variable:
+
+```bash
+export CLAUDINE_ENABLE_WEB_SEARCH=true
+claudine start
+```
+
+Once enabled, Claude automatically decides when to search based on your queries. Results appear as markdown-formatted links in the response.
+
+**Supported Models:**
+- claude-sonnet-4-5-20250929 (Claude Sonnet 4.5)
+- claude-sonnet-4-20250514 (Claude Sonnet 4)
+- claude-haiku-4-5-20251001 (Claude Haiku 4.5)
+- claude-opus-4 and claude-opus-4.1
+
+**Pricing:** $10 per 1,000 searches (charged by Anthropic)
+
+**Example queries:**
+- "What are the latest developments in AI today?"
+- "What's the current weather in San Francisco?"
+- "Find recent news about SpaceX launches"
+
+For OpenAI-compatible clients, you can also enable web search per-request using `web_search_options`:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer claudine" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250929",
+    "messages": [{"role": "user", "content": "Latest AI news?"}],
+    "web_search_options": {
+      "user_location": {
+        "type": "approximate",
+        "approximate": {"city": "San Francisco"}
+      }
+    }
+  }'
+```
+
+**Note:** OpenAI's `search_context_size` parameter is not supported (Claude manages context automatically).
+
 ## Supported Tools & Editors
 
 Any tool that supports BYOM (Bring Your Own Models) with OpenAI-compatible endpoints works with Claudine. Here are a few popular examples:
@@ -121,6 +165,8 @@ In Settings, add a new Model Provider pointing to `http://localhost:4000/v1` and
 
 Enable Custom AI providers and add Claudine to your list of custom providers.
 
+**For web search:** Set `CLAUDINE_ENABLE_WEB_SEARCH=true` before starting Claudine. Raycast will then use Claude's web search automatically when needed.
+
 <details>
 <summary>example configuration (`providers.yaml`)</summary>
 
@@ -131,8 +177,11 @@ providers:
   - id: claudine
     name: Claudine
     base_url: http://localhost:4000/v1
+    # to enable web search in providers.yaml
+    additional_parameters:
+      web_search_options: {}
     models:
-      - id: claude-sonnet-4-5
+      - id: claude-sonnet-4-5-20250929
         name: "Claude Sonnet 4.5"
         context: 205400
         abilities:
@@ -147,6 +196,16 @@ providers:
           reasoning_effort:
             supported: true
       # ...
+```
+
+**To enable web search with Raycast:**
+```bash
+# Set environment variable before starting
+export CLAUDINE_ENABLE_WEB_SEARCH=true
+claudine start
+
+# Or for macOS launchd service, add to your plist:
+# <key>CLAUDINE_ENABLE_WEB_SEARCH</key><string>true</string>
 ```
 
 </details>
@@ -194,6 +253,7 @@ Run `claudine --help` for all available options.
 | `CLAUDINE_LOG_FORMAT` | Log output format (`text` or `json`) | `text` |
 | `CLAUDINE_SERVER__HOST` | Server bind address | `127.0.0.1` |
 | `CLAUDINE_SERVER__PORT` | Server listen port | `4000` |
+| `CLAUDINE_ENABLE_WEB_SEARCH` | Enable web search for all requests | `false` |
 
 <details>
 <summary><b>View all environment variables</b></summary>

--- a/internal/openaiadapter/anthropicclaude/messages.go
+++ b/internal/openaiadapter/anthropicclaude/messages.go
@@ -399,14 +399,18 @@ func textFromAnthropicContentBlocks(content []anthropic.ContentBlockUnion) strin
 				texts = append(texts, variant.Text)
 			}
 		case anthropic.WebSearchToolResultBlock:
-			// Extract text representation from web search tool results
+			// Extract text representation from web search tool results as numbered links
 			// The Content field can contain an array of WebSearchResultBlocks
 			searchResults := variant.Content.AsWebSearchResultBlockArray()
-			for _, result := range searchResults {
-				if result.Title != "" && result.URL != "" {
-					searchResult := fmt.Sprintf("[%s](%s)", result.Title, result.URL)
-					texts = append(texts, searchResult)
+			var formattedResults []string
+			for i, result := range searchResults {
+				if result.URL != "" {
+					formattedResults = append(formattedResults, fmt.Sprintf("[%d](%s)", i+1, result.URL))
 				}
+			}
+			if len(formattedResults) > 0 {
+				// Join all numbered links with spaces on a single line
+				texts = append(texts, strings.Join(formattedResults, " "))
 			}
 			// If it's an error, the Content will have error details which we skip
 		case anthropic.ServerToolUseBlock:

--- a/internal/openaiadapter/anthropicclaude/messages.go
+++ b/internal/openaiadapter/anthropicclaude/messages.go
@@ -398,6 +398,22 @@ func textFromAnthropicContentBlocks(content []anthropic.ContentBlockUnion) strin
 			if variant.Text != "" {
 				texts = append(texts, variant.Text)
 			}
+		case anthropic.WebSearchToolResultBlock:
+			// Extract text representation from web search tool results
+			// The Content field can contain an array of WebSearchResultBlocks
+			searchResults := variant.Content.AsWebSearchResultBlockArray()
+			for _, result := range searchResults {
+				if result.Title != "" && result.URL != "" {
+					searchResult := fmt.Sprintf("[%s](%s)", result.Title, result.URL)
+					texts = append(texts, searchResult)
+				}
+			}
+			// If it's an error, the Content will have error details which we skip
+		case anthropic.ServerToolUseBlock:
+			// ServerToolUseBlock represents server-side tool execution (e.g., web search)
+			// Skip these blocks as they don't contain text content for the user
+			// The actual results will appear in WebSearchToolResultBlock
+			continue
 		}
 	}
 	return strings.Join(texts, "\n")


### PR DESCRIPTION
# Web Search Implementation Details

> **User Documentation:** See the [Web Search section in README.md](https://github.com/florianilch/claudine-proxy/compare/main...hllvc:claudine-proxy:feat/enable-web-search?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109) for usage instructions.

## Overview

This document describes the technical implementation of Claude's web search capability in claudine-proxy.

## What Was Implemented

### 1. **Web Search Tool Injection** (`generation.go`)
- Automatically injects Anthropic's `WebSearchTool20250305` when web search is enabled
- Supports OpenAI's `WebSearchOptions` parameter format
- Can be enabled via environment variable for clients that don't support `WebSearchOptions`

### 2. **Response Content Handling** (`messages.go`)
- Extracts web search results from Anthropic's `WebSearchToolResultBlock` content
- Converts search results to markdown format: `[Title](URL)`
- Skips `ServerToolUseBlock` markers (internal execution details)

### 3. **Streaming Support** (`chat_completion.go`)
- Handles `server_tool_use` and `web_search_tool_result` content blocks in streaming responses
- Web search results are accumulated and included in the final message

### 4. **Configuration**
- Environment variable `CLAUDINE_ENABLE_WEB_SEARCH=true` enables web search by default
- Useful for Raycast and other clients that don't send `WebSearchOptions`

## Technical Details

### Modified Files
- `internal/openaiadapter/anthropicclaude/generation.go` - Tool injection logic
- `internal/openaiadapter/anthropicclaude/messages.go` - Result extraction
- `internal/openaiadapter/anthropicclaude/chat_completion.go` - Streaming support

### Supported Models
Web search is available for:
- claude-sonnet-4-5-20250929 (Claude Sonnet 4.5)
- claude-sonnet-4-20250514 (Claude Sonnet 4)
- claude-haiku-4-5-20251001 (Claude Haiku 4.5)
- claude-opus-4 and claude-opus-4.1

### Configuration Options

#### Environment Variable
- `CLAUDINE_ENABLE_WEB_SEARCH=true` - Enable web search for all requests

#### Request Parameter (OpenAI-compatible clients)
Clients can also enable web search per-request by sending:
```json
{
  "model": "claude-sonnet-4-5-20250929",
  "messages": [...],
  "web_search_options": {
    "search_context_size": "medium",
    "user_location": {
      "type": "approximate",
      "approximate": {
        "city": "San Francisco"
      }
    }
  }
}
```

Note: OpenAI's `search_context_size` parameter is not directly supported by Anthropic's API (Claude manages context automatically).

## Limitations

1. **Search Context Size**: OpenAI's `search_context_size` parameter has no direct Anthropic equivalent
2. **Structured Results**: Web search results are converted to simple markdown links (title + URL)
3. **Max Uses**: Default max uses per request is unlimited; can be configured by modifying the tool parameter
4. **Domains**: Currently no domain filtering (allowed/blocked domains)

## Future Enhancements

To add more configuration options, consider:
- Max uses per request
- Allowed/blocked domain filtering
- Per-model web search enablement
- Proper configuration struct in `config.go` instead of environment variable

## Testing

To verify the implementation works:

```bash
# Start claudine-proxy with web search enabled
CLAUDINE_ENABLE_WEB_SEARCH=true ./claudine-proxy

# In another terminal, test with curl
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer claudine" \
  -d '{
    "model": "claude-sonnet-4-5-20250929",
    "messages": [
      {"role": "user", "content": "What are the latest AI news today?"}
    ]
  }'
```

Look for markdown-formatted links like `[Article Title](https://url.com)` in the response.

## Debugging

**Verify web search is enabled:**
```bash
# Check environment variable is set
echo $CLAUDINE_ENABLE_WEB_SEARCH

# Check logs for web search tool injection
export CLAUDINE_LOG_LEVEL=debug
claudine start
```

**Check response formatting:**
- Web search results should appear as `[Title](URL)` markdown links
- If you see raw blocks, check the `textFromAnthropicContentBlocks` function in `messages.go`
