### PR TITLE
Add static /v1/models endpoint for model discovery

### DIFF
--- a/internal/proxy/models.go
+++ b/internal/proxy/models.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	_ "embed"
+	"log/slog"
+	"net/http"
+)
+
+//go:embed models.json
+var modelsJSON []byte
+
+// modelsHandler returns a static list of available Anthropic models.
+// The upstream /v1/models endpoint doesn't support OAuth authentication,
+// so we serve a cached response to enable model selection in clients.
+//
+// The response uses a merged format compatible with both Anthropic and OpenAI
+// clients, combining fields from both API specifications. This approach assumes
+// that most clients ignore unknown fields.
+func modelsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(modelsJSON); err != nil {
+			slog.ErrorContext(r.Context(), "failed to write response", "error", err)
+		}
+	}
+}

--- a/internal/proxy/models.json
+++ b/internal/proxy/models.json
@@ -1,0 +1,80 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-haiku-4-5-20251001",
+      "display_name": "Claude Haiku 4.5",
+      "created_at": "2025-10-15T00:00:00Z",
+      "created": 1760486400,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-sonnet-4-5-20250929",
+      "display_name": "Claude Sonnet 4.5",
+      "created_at": "2025-09-29T00:00:00Z",
+      "created": 1759104000,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-opus-4-1-20250805",
+      "display_name": "Claude Opus 4.1",
+      "created_at": "2025-08-05T00:00:00Z",
+      "created": 1754352000,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-opus-4-20250514",
+      "display_name": "Claude Opus 4",
+      "created_at": "2025-05-22T00:00:00Z",
+      "created": 1747872000,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-sonnet-4-20250514",
+      "display_name": "Claude Sonnet 4",
+      "created_at": "2025-05-22T00:00:00Z",
+      "created": 1747872000,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-3-7-sonnet-20250219",
+      "display_name": "Claude Sonnet 3.7",
+      "created_at": "2025-02-24T00:00:00Z",
+      "created": 1740355200,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-3-5-haiku-20241022",
+      "display_name": "Claude Haiku 3.5",
+      "created_at": "2024-10-22T00:00:00Z",
+      "created": 1729555200,
+      "owned_by": "anthropic"
+    },
+    {
+      "type": "model",
+      "object": "model",
+      "id": "claude-3-haiku-20240307",
+      "display_name": "Claude Haiku 3",
+      "created_at": "2024-03-07T00:00:00Z",
+      "created": 1709769600,
+      "owned_by": "anthropic"
+    }
+  ],
+  "has_more": false,
+  "first_id": "claude-haiku-4-5-20251001",
+  "last_id": "claude-3-haiku-20240307"
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -145,6 +145,15 @@ func New(ts oauth2.TokenSource, health ReadinessChecker, opts ...Option) (*Proxy
 		middleware.RequestIDPropagation,
 	))
 
+	// Shared static Models API endpoint for OpenAI and Anthropic
+	mux.Handle("GET "+upstream.Path+"/models", applyMiddlewares(modelsHandler(),
+		middleware.Logging(logger),
+		Recovery,
+		middleware.TraceContextExtraction,
+		middleware.RequestIDGeneration,
+		middleware.RequestIDPropagation,
+	))
+
 	// Health check endpoints
 	mux.HandleFunc("GET /health/liveness", livenessHandler())
 	mux.HandleFunc("GET /health/readiness", readinessHandler(health))


### PR DESCRIPTION
Upstream endpoint doesn't support OAuth, so we serve a cached model list to enable client model selection. Response uses merged Anthropic/OpenAI format for compatibility.