### PR TITLE
Return 413 status code when request size limit exceeded

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -131,7 +131,7 @@ func New(ts oauth2.TokenSource, health ReadinessChecker, opts ...Option) (*Proxy
 		Recovery,
 		middleware.TraceContextExtraction,
 		middleware.RequestIDGeneration,
-		RequestSizeLimit(100<<20),
+		RequestSizeLimit(33<<20), // Anthropic enforces 32MB
 		middleware.RequestIDPropagation,
 	))
 
@@ -141,7 +141,7 @@ func New(ts oauth2.TokenSource, health ReadinessChecker, opts ...Option) (*Proxy
 		Recovery,
 		middleware.TraceContextExtraction,
 		middleware.RequestIDGeneration,
-		RequestSizeLimit(100<<20),
+		RequestSizeLimit(31<<20), // proxy handles error
 		middleware.RequestIDPropagation,
 	))
 


### PR DESCRIPTION
- Handle MaxBytesError to return proper 413 Request Entity Too Large response
- Adjust limits to align with Anthropic's 32MB constraint