### PR TITLE
Fix `budget_tokens` in extra body

### DIFF
--- a/internal/openaiadapter/anthropicclaude/testdata/buffered/reasoning.json
+++ b/internal/openaiadapter/anthropicclaude/testdata/buffered/reasoning.json
@@ -211,5 +211,80 @@
         "total_tokens": 113
       }
     }
+  },
+  {
+    "openaiRequest": {
+      "model": "claude-3-5-sonnet-20241022",
+      "messages": [
+        {"role": "user", "content": "What is the time complexity of quicksort?"}
+      ],
+      "reasoning_effort": "low",
+      "extra_body": {
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": "5000"
+        }
+      },
+      "max_completion_tokens": 1024
+    },
+    "anthropicRequest": {
+      "model": "claude-3-5-sonnet-20241022",
+      "messages": [
+        {"role": "user", "content": [{"type": "text", "text": "What is the time complexity of quicksort?"}]}
+      ],
+      "thinking": {
+        "type": "enabled",
+        "budget_tokens": 5000
+      },
+      "max_tokens": 1024
+    },
+    "anthropicResponse": {
+      "id": "msg_01think004",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "Average O(n log n), worst O(n²) with bad pivots."
+        },
+        {
+          "type": "text",
+          "text": "Quicksort has O(n log n) average-case time complexity and O(n²) worst-case when the pivot choices are poor."
+        }
+      ],
+      "model": "claude-3-5-sonnet-20241022",
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "usage": {
+        "input_tokens": 22,
+        "output_tokens": 78,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0
+      }
+    },
+    "openaiResponse": {
+      "id": "msg_01think004",
+      "object": "chat.completion",
+      "created": 0,
+      "model": "claude-3-5-sonnet-20241022",
+      "service_tier": null,
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "Quicksort has O(n log n) average-case time complexity and O(n²) worst-case when the pivot choices are poor.",
+            "refusal": null
+          },
+          "finish_reason": "stop",
+          "logprobs": null
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 22,
+        "completion_tokens": 78,
+        "total_tokens": 100
+      }
+    }
   }
 ]

--- a/internal/openaiadapter/anthropicclaude/testdata/streaming/reasoning_stream.json
+++ b/internal/openaiadapter/anthropicclaude/testdata/streaming/reasoning_stream.json
@@ -328,5 +328,119 @@
         }
       }
     ]
+  },
+  {
+    "openaiRequest": {
+      "model": "claude-3-5-sonnet-20241022",
+      "messages": [
+        {"role": "user", "content": "What is the time complexity of quicksort?"}
+      ],
+      "reasoning_effort": "low",
+      "extra_body": {
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": "5000"
+        }
+      },
+      "max_completion_tokens": 1024,
+      "stream": true
+    },
+    "anthropicRequest": {
+      "model": "claude-3-5-sonnet-20241022",
+      "messages": [
+        {"role": "user", "content": [{"type": "text", "text": "What is the time complexity of quicksort?"}]}
+      ],
+      "thinking": {
+        "type": "enabled",
+        "budget_tokens": 5000
+      },
+      "max_tokens": 1024,
+      "stream": true
+    },
+    "anthropicSSE": [
+      "event: message_start",
+      "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01think004\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-sonnet-20241022\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":22,\"output_tokens\":0}}}",
+      "",
+      "event: content_block_start",
+      "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+      "",
+      "event: content_block_delta",
+      "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Average O(n log n), worst O(n²) with bad pivots.\"}}",
+      "",
+      "event: content_block_stop",
+      "data: {\"type\":\"content_block_stop\",\"index\":0}",
+      "",
+      "event: content_block_start",
+      "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+      "",
+      "event: content_block_delta",
+      "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Quicksort has O(n log n) average-case time complexity and O(n²) worst-case when the pivot choices are poor.\"}}",
+      "",
+      "event: content_block_stop",
+      "data: {\"type\":\"content_block_stop\",\"index\":1}",
+      "",
+      "event: message_delta",
+      "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":78}}",
+      "",
+      "event: message_stop",
+      "data: {\"type\":\"message_stop\"}",
+      ""
+    ],
+    "openaiChunks": [
+      {
+        "id": "msg_01think004",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "claude-3-5-sonnet-20241022",
+        "service_tier": null,
+        "choices": [
+          {
+            "index": 0,
+            "delta": {
+              "role": "assistant"
+            },
+            "finish_reason": null,
+            "logprobs": null
+          }
+        ]
+      },
+      {
+        "id": "msg_01think004",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "claude-3-5-sonnet-20241022",
+        "service_tier": null,
+        "choices": [
+          {
+            "index": 0,
+            "delta": {
+              "content": "Quicksort has O(n log n) average-case time complexity and O(n²) worst-case when the pivot choices are poor."
+            },
+            "finish_reason": null,
+            "logprobs": null
+          }
+        ]
+      },
+      {
+        "id": "msg_01think004",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "claude-3-5-sonnet-20241022",
+        "service_tier": null,
+        "choices": [
+          {
+            "index": 0,
+            "delta": {},
+            "finish_reason": "stop",
+            "logprobs": null
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 22,
+          "completion_tokens": 78,
+          "total_tokens": 100
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Support parsing `budget_tokens` from string format in `extra_body.thinking` configuration. Add test coverage for string format in reasoning fixtures.